### PR TITLE
ios fix full vertical page display

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr">
+<html lang="fr" class="h-full">
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
@@ -56,11 +56,11 @@
     ></script>
     <% } %>
   </head>
-  <body>
+  <body class="h-full">
     <noscript
       >Vous devez activer Javascript pour utiliser cette application.</noscript
     >
-    <div id="root"></div>
+    <div id="root" class="h-full"></div>
     <!--
       This HTML file is a template.
       If you open it directly in the browser, you will see an empty page.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -253,7 +253,7 @@ function App() {
   }
 
   return (
-    <div className="h-screen flex flex-col">
+    <div className="h-full flex flex-col">
       <Navbar
         setIsInfoModalOpen={setIsInfoModalOpen}
         setIsStatsModalOpen={setIsStatsModalOpen}


### PR DESCRIPTION
This fix vertical truncate on ios/safari. 

[Taken from here](https://github.com/cwackerfuss/react-wordle/pull/429/commits/b520226f714f9fe72bdbaa1d3242e0628368d857)